### PR TITLE
make the project reservation work on CRDs

### DIFF
--- a/artifacts/example/reserve-deads.yaml
+++ b/artifacts/example/reserve-deads.yaml
@@ -1,0 +1,4 @@
+apiVersion: online.openshift.io/v1alpha1
+kind: NamespaceReservation
+metadata:
+  name: deads

--- a/artifacts/install/rbac-template.yaml
+++ b/artifacts/install/rbac-template.yaml
@@ -35,14 +35,14 @@ objects:
     - namespacereservations
     verbs:
     - get
-      list
-      watch
+    - list
+    - watch
 
 # to let the admission server read the namespace reservations
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
-    name: tsb-${NAMESPACE}
+    name: namespace-reservation-server-${NAMESPACE}
   roleRef:
     kind: ClusterRole
     name: system:openshift:online:namespace-reservation-server

--- a/cmd/namespacereservationserver/main.go
+++ b/cmd/namespacereservationserver/main.go
@@ -6,11 +6,15 @@ import (
 	"net/http"
 
 	admissionv1alpha1 "k8s.io/api/admission/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+
+	"sync"
 
 	"github.com/openshift/kubernetes-namespace-reservation/pkg/genericadmissionserver/cmd"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func main() {
@@ -18,6 +22,10 @@ func main() {
 }
 
 type admissionHook struct {
+	reservationClient dynamic.ResourceInterface
+
+	lock        sync.RWMutex
+	initialized bool
 }
 
 func (a *admissionHook) Resource() (plural schema.GroupVersionResource, singular string) {
@@ -46,41 +54,81 @@ func (a *admissionHook) Admit(admissionSpec admissionv1alpha1.AdmissionReviewSpe
 	if err != nil {
 		status.Allowed = false
 		status.Result = &metav1.Status{
-			Status:  metav1.StatusFailure,
-			Code:    http.StatusBadRequest,
-			Reason:  metav1.StatusReasonBadRequest,
+			Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
 			Message: err.Error(),
 		}
 		return status
 	}
-
 	if len(admittingObjectName.Name) == 0 {
 		status.Allowed = false
 		status.Result = &metav1.Status{
-			Status:  metav1.StatusFailure,
-			Code:    http.StatusForbidden,
-			Reason:  metav1.StatusReasonForbidden,
+			Status: metav1.StatusFailure, Code: http.StatusForbidden, Reason: metav1.StatusReasonForbidden,
 			Message: "name is required",
 		}
 		return status
 	}
 
-	if admittingObjectName.Name == "fail-me" {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+	if !a.initialized {
 		status.Allowed = false
 		status.Result = &metav1.Status{
-			Status:  metav1.StatusFailure,
-			Code:    http.StatusForbidden,
-			Reason:  metav1.StatusReasonForbidden,
-			Message: fmt.Sprintf("%q is reserved", admittingObjectName.Name),
+			Status: metav1.StatusFailure, Code: http.StatusInternalServerError, Reason: metav1.StatusReasonInternalError,
+			Message: "not initialized",
 		}
 		return status
 	}
 
-	status.Allowed = true
+	_, err = a.reservationClient.Get(admittingObjectName.Name, metav1.GetOptions{})
+	if err == nil {
+		status.Allowed = false
+		status.Result = &metav1.Status{
+			Status: metav1.StatusFailure, Code: http.StatusForbidden, Reason: metav1.StatusReasonForbidden,
+			Message: fmt.Sprintf("%q is reserved", admittingObjectName.Name),
+		}
+		return status
+	}
+	if apierrors.IsNotFound(err) {
+		status.Allowed = true
+		return status
+	}
+
+	status.Allowed = false
+	status.Result = &metav1.Status{
+		Status: metav1.StatusFailure, Code: http.StatusInternalServerError, Reason: metav1.StatusReasonInternalError,
+		Message: err.Error(),
+	}
 	return status
 }
 
-func (a *admissionHook) Initialize(context genericapiserver.PostStartHookContext) error {
+func (a *admissionHook) Initialize(kubeClientConfig *rest.Config, stopCh <-chan struct{}) error {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	a.initialized = true
+
+	shallowClientConfigCopy := *kubeClientConfig
+	shallowClientConfigCopy.GroupVersion = &schema.GroupVersion{
+		Group:   "online.openshift.io",
+		Version: "v1alpha1",
+	}
+	shallowClientConfigCopy.APIPath = "/apis"
+	dynamicClient, err := dynamic.NewClient(&shallowClientConfigCopy)
+	if err != nil {
+		return err
+	}
+	a.reservationClient = dynamicClient.Resource(
+		&metav1.APIResource{
+			Name:       "namespacereservations",
+			Namespaced: false,
+			Group:      "online.openshift.io",
+			Version:    "v1alpha1",
+			// kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')
+			Kind: "NamespaceReservation",
+		},
+		"",
+	)
+
 	return nil
 }
 

--- a/pkg/genericadmissionserver/cmd/cmd.go
+++ b/pkg/genericadmissionserver/cmd/cmd.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openshift/kubernetes-namespace-reservation/pkg/genericadmissionserver/apiserver"
 	"github.com/openshift/kubernetes-namespace-reservation/pkg/genericadmissionserver/cmd/server"
+	"k8s.io/client-go/rest"
 )
 
 // AdmissionHook is what callers provide.  We define it here to limit how much of the import tree
@@ -27,7 +28,7 @@ type AdmissionHook interface {
 	Admit(admissionSpec admissionv1alpha1.AdmissionReviewSpec) admissionv1alpha1.AdmissionReviewStatus
 
 	// Initialize is called as a post-start hook
-	Initialize(context genericapiserver.PostStartHookContext) error
+	Initialize(kubeClientConfig *rest.Config, stopCh <-chan struct{}) error
 }
 
 func RunAdmission(admissionHooks ...AdmissionHook) {


### PR DESCRIPTION
This is the final wiring.  It uses a dynamic client to check to see if a reservation is present.

@dgoodwin at this point, I'll write enough tests to give you a rough example of how to write more.  Then I think I'll leave the rest of the build-out to you.

I may or may not create the generic admission server repo.  It does seem pretty handy.  I suspect very few people could actually wire it correctly.